### PR TITLE
resolve-all-services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
 ## 0.1.0
 
 - Initial version
+
+## 0.2.0
+
+- Bug fixes.
+- The class InjectionContext is now private and the functions are the only API starting as of this version.
+  - There are new function `startup` and `shutDown` to start and reset the injection context.
+- Added the function `resolveAll` to retrieve all services that implement the given class

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A very simple and easy to use dependency injection framework for Dart.
 A simple usage example:
 
 ```dart
-import 'package:dart_inject/dart_inject.dart';
+import 'package:dart_inject/dart_inject.dart' as di;
 
 abstract class Vehicle {
   String get name;
@@ -25,15 +25,14 @@ class Car implements Vehicle {
 }
 
 void main() {
-  InjectionContext().startup((context) {
-    register<Vehicle>(() => Car('BMW X6'));
+  di.startup((context) {
+    di.register<Vehicle>(() => Car('BMW X6'));
   });
 
-  var car = resolve<Vehicle>();
+  var car = di.resolve<Vehicle>();
   var carName = car.name;
   print('I own a $carName');
 }
-
 ```
 
 ## Features and bugs

--- a/example/dart_inject_example.dart
+++ b/example/dart_inject_example.dart
@@ -1,4 +1,4 @@
-import 'package:dart_inject/dart_inject.dart';
+import 'package:dart_inject/dart_inject.dart' as di;
 
 abstract class Vehicle {
   String get name;
@@ -16,11 +16,11 @@ class Car implements Vehicle {
 }
 
 void main() {
-  InjectionContext().startup((context) {
-    register<Vehicle>(() => Car('BMW X6'));
+  di.startup((context) {
+    di.register<Vehicle>(() => Car('BMW X6'));
   });
 
-  var car = resolve<Vehicle>();
+  var car = di.resolve<Vehicle>();
   var carName = car.name;
   print('I own a $carName');
 }

--- a/lib/src/injection_context.dart
+++ b/lib/src/injection_context.dart
@@ -13,8 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import 'dart:mirrors';
 
 import 'exceptions.dart';
+
+String _typeOf<T>() => reflectClass(T).reflectedType.toString();
 
 /// This function type defines the signature for functions that initialize a
 /// service instances.
@@ -22,7 +25,7 @@ typedef ServiceInitializer<T> = T Function();
 
 /// This the function type definition for the initialization of the available
 /// services. The function is called with the [context].
-typedef InjectionInitializer = void Function(InjectionContext context);
+typedef InjectionInitializer = void Function(_InjectionContext context);
 
 class _ServiceConfiguration<T> {
   String name;
@@ -33,26 +36,26 @@ class _ServiceConfiguration<T> {
   _ServiceConfiguration({this.name, this.serviceInitializer, this.singleton});
 }
 
-/// The [InjectionContext] is the global registry for all services. It is a
+/// The [_InjectionContext] is the global registry for all services. It is a
 /// singleton, since the context must be the same instance in the entire
 /// application.
-class InjectionContext {
-  /// The singleton instance of the [InjectionContext].
-  static final InjectionContext _singleton = InjectionContext._global();
+class _InjectionContext {
+  /// The singleton instance of the [_InjectionContext].
+  static final _InjectionContext _singleton = _InjectionContext._global();
 
   /// This flag determines whether the [startup] method has been called or not.
-  /// If the [startup] method has not been calledm the [InjectionContext] is not
+  /// If the [startup] method has not been calledm the [_InjectionContext] is not
   /// functional and each call to any method results in an error.
   bool _initialized = false;
 
   Map<String, _ServiceConfiguration> _services = {};
 
   /// Internal constructor for the singleton.
-  InjectionContext._global();
+  _InjectionContext._global();
 
   /// This factory always returns the singleton instance of the
-  /// [InjectionContext].
-  factory InjectionContext() {
+  /// [_InjectionContext].
+  factory _InjectionContext() {
     return _singleton;
   }
 
@@ -97,14 +100,14 @@ class InjectionContext {
     }
 
     if (_services.containsKey(_key<T>(name))) {
-      throw InjectionContextHasAlreadyService(T.runtimeType.toString(), name ?? T.runtimeType.toString());
+      throw InjectionContextHasAlreadyService(_typeOf<T>(), (name ?? _typeOf<T>()));
     }
 
-    _services[_key(name)] =
+    _services[_key<T>(name)] =
         _ServiceConfiguration<T>(name: name, serviceInitializer: initializer, singleton: asSingleton);
   }
 
-  /// This method resolves a service determined by the type[T] and an optional
+  /// This method resolves a service determined by the type [T] and an optional
   /// [name].
   ///
   /// Throws a [InjectionContextNotInitialized] exception, if the injection
@@ -118,10 +121,33 @@ class InjectionContext {
     }
 
     if (!_services.containsKey(_key<T>(name))) {
-      throw InjectionContextHasNoService(T.runtimeType.toString(), name ?? T.runtimeType.toString());
+      throw InjectionContextHasNoService(_typeOf<T>(), (name ?? _typeOf<T>()));
     }
-    var configuration = _services[_key<T>(name)];
 
+    return _instanceForConfiguration(_services[_key<T>(name)]);
+  }
+
+  /// This method resolves a service determined by the type [T].
+  ///
+  /// Throws a [InjectionContextNotInitialized] exception, if the injection
+  /// context is not started.
+  List<T> resolveAll<T>() {
+    if (!_initialized) {
+      throw InjectionContextNotInitialized();
+    }
+
+    var services = <T>[];
+
+    _services.keys.toList().forEach((key) {
+      if (key.startsWith(_typeOf<T>() + ':')) {
+        services.add(_instanceForConfiguration(_services[key]));
+      }
+    });
+
+    return services;
+  }
+
+  dynamic _instanceForConfiguration<T>(_ServiceConfiguration<T> configuration) {
     if (configuration.singleton) {
       configuration.serviceInstance ??= configuration.serviceInitializer();
 
@@ -132,15 +158,49 @@ class InjectionContext {
   }
 
   String _key<T>(String name) {
-    return T.runtimeType.toString() + ':' + (name ?? T.runtimeType.toString());
+    return _typeOf<T>() + ':' + (name ?? _typeOf<T>());
   }
 }
 
-/// This is a convenience method that simply forwards the call to the method
-/// [register] of the class [InjectionContext].
-void register<T>(ServiceInitializer<T> initializer, {String name, bool asSingleton = true}) =>
-    InjectionContext().register(initializer, name: name, asSingleton: asSingleton);
+/// This function must be called at the very beginning of the application to initialize
+/// the injection context.
+void startup(InjectionInitializer initializer) => _InjectionContext().startup(initializer);
 
-/// This is a convenience method that simply forwards the call to the method
-/// [resolve] of the class [InjectionContext].
-T resolve<T>({String name}) => InjectionContext().resolve(name: name);
+/// This function can be called to reset the injection context. Every registered
+/// service and all singleton instances will be removed.
+void shutDown() => _InjectionContext().shutDown();
+
+/// This function shall be called to register a service with the injection
+/// context. It must only be called, after the [startup] has been called.
+///
+/// The [initializer] is called when an instance of the service shall be
+/// created. It must return the instance of the service. By passing a [name],
+/// it is possible to register different services that implement the same
+/// class. If the flag [asSingleton] is true, the [initializer] is only called
+/// once when resolving the service. The created service instance will be
+/// cached. If the flag [asSingleton] is false, the [initializer] is called
+/// every time when resolving the service.
+///
+/// Throws a [InjectionContextNotInitialized] exception, if the injection
+/// context is not started.
+///
+/// Throws a [InjectionContextHasAlreadyService] exception, if the service
+/// that shall be registered was already registered before.
+void register<T>(ServiceInitializer<T> initializer, {String name, bool asSingleton = true}) =>
+    _InjectionContext().register<T>(initializer, name: name, asSingleton: asSingleton);
+
+/// This function resolves a service determined by the type [T] and an optional
+/// [name].
+///
+/// Throws a [InjectionContextNotInitialized] exception, if the injection
+/// context is not started.
+///
+/// Throws a [InjectionContextHasNoService] exception, if the service
+/// that shall be resolved was not registered before.
+T resolve<T>({String name}) => _InjectionContext().resolve<T>(name: name);
+
+/// This function resolves a service determined by the type [T].
+///
+/// Throws a [InjectionContextNotInitialized] exception, if the injection
+/// context is not started.
+List<T> resolveAll<T>() => _InjectionContext().resolveAll<T>();


### PR DESCRIPTION
- Bug fixes.
- The class InjectionContext is now private and the functions are the only API starting as of this version.
  - There are new function `startup` and `shutDown` to start and reset the injection context.
- Added the function `resolveAll` to retrieve all services that implement the given class